### PR TITLE
Refactor State and Simulation

### DIFF
--- a/src/simulation.rs
+++ b/src/simulation.rs
@@ -6,6 +6,23 @@ use rand::rngs::StdRng;
 use crate::Time;
 use crate::road::Road;
 use crate::time::TIME_RESOLUTION;
+use crate::time::TimeDelta;
+use crate::state::{State, SimulatorState};
+use crate::vehicle::{Vehicle, Car};
+
+
+pub trait SimTrait {
+
+    // get time interval until next event
+    fn time_to_next_event(&self) -> TimeDelta;
+
+    // roll simulation forward by time interval
+    fn roll_forward_by(&mut self, time_delta: TimeDelta);
+
+    // update simulation state
+    fn instantaneous_update(&mut self);
+
+}
 
 pub struct Simulation {
 
@@ -20,7 +37,8 @@ pub struct Simulation {
     pub ped_arrival_times: Vec<Time>,
     pub veh_arrival_times: Vec<Time>,
 
-    road: Road
+    road: Road,
+    state: Box<dyn State>
 }
 
 impl Simulation {
@@ -33,6 +51,8 @@ impl Simulation {
         road: Road) -> Simulation {
 
         assert!(end_time > start_time);
+        assert!(ped_arrival_rate >= 0.0);
+        assert!(veh_arrival_rate >= 0.0);
 
         // Set the random seed.
         // See https://stackoverflow.com/questions/59020767/how-can-i-input-an-integer-seed-for-producing-random-numbers-using-the-rand-crat
@@ -42,6 +62,9 @@ impl Simulation {
         let ped_arrival_times = arrival_times(&start_time, &end_time, ped_arrival_rate, &mut rng);
         let veh_arrival_times = arrival_times(&start_time, &end_time, veh_arrival_rate, &mut rng);
 
+        // Construct initial (empty) state at time 0.
+        let state = Box::new(SimulatorState::new());
+
         let sim = Simulation {
             seed,
             start_time,
@@ -50,18 +73,56 @@ impl Simulation {
             veh_arrival_rate,
             ped_arrival_times,
             veh_arrival_times,
-            road
+            road,
+            state
         };
 
-        // TODO. Construct initial (empty) state at time 0.
-        // ...
-
         sim
+    }
+
+    // Set the state arbitrarily. Useful for testing, but private.
+    fn set_state(&mut self, state: Box<dyn State>) {
+        self.state = state;
+    }
+
+    fn set_ped_arrival_times(&mut self, ped_arrival_times: Vec<Time>) {
+        self.ped_arrival_times = ped_arrival_times;
+    }
+
+    fn set_veh_arrival_times(&mut self, veh_arrival_times: Vec<Time>) {
+        self.veh_arrival_times = veh_arrival_times;
     }
 
     // pub fn current_state() -> State {
 
     // }
+}
+
+impl SimTrait for Simulation {
+
+    // get time interval until next event
+    fn time_to_next_event(&self) -> TimeDelta {
+
+        // get min of pedestrian and vehicle arrival times
+        let min_ped_times = self.ped_arrival_times.iter().min().unwrap();
+        let min_veh_times = self.veh_arrival_times.iter().min().unwrap();
+
+        // return the smallest of the two times as the next event
+        if min_veh_times < min_ped_times {
+            return TimeDelta::new(*min_veh_times);
+        }
+        TimeDelta::new(*min_ped_times)
+    }
+
+    // roll state forward by time interval
+    fn roll_forward_by(&mut self, time_delta: TimeDelta) {
+
+    }
+
+    // update state
+    fn instantaneous_update(&mut self) {
+
+    }
 }
 
 fn arrival_times(start_time: &Time, end_time: &Time, arrival_rate: f32, rng: &mut StdRng) -> Vec<Time> {
@@ -84,6 +145,93 @@ fn interarrival_time(arrival_rate: f32, rng: &mut StdRng) -> Time {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    fn test_sim() -> Simulation {
+        let road = Road::new(100.0, Vec::new());
+        Simulation::new(147, 0, 60000, 0.1, 0.2, road)
+    }
+
+    #[test]
+    fn test_set_state() {
+
+        let mut sim = test_sim();
+        assert_eq!(sim.state.timestamp(), &0);
+
+        // Construct a new state with a non-zero timestamp.
+        let new_timestamp = 10000;
+        let new_state = SimulatorState::dummy(Vec::new(), Vec::new(), new_timestamp);
+
+        // Set the simulation state.
+        sim.set_state(Box::new(new_state));
+        assert_eq!(sim.state.timestamp(), &new_timestamp);
+    }
+
+    #[test]
+    fn test_set_arrival_times() {
+
+        let mut sim = test_sim();
+        assert_ne!(sim.ped_arrival_times, vec!(10000, 20000));
+
+        // Construct new pedestrian arrival times.
+        let ped_arrival_times = vec!(10000, 20000);
+
+        // Set the simulation pedestrian arrival times.
+        sim.set_ped_arrival_times(ped_arrival_times);
+        assert_eq!(sim.ped_arrival_times, vec!(10000, 20000));
+
+        // Construct new vehicle arrival times.
+        let veh_arrival_times = vec!(12000, 21000);
+
+        // Set the simulation vehicle arrival times.
+        sim.set_veh_arrival_times(veh_arrival_times);
+        assert_eq!(sim.veh_arrival_times, vec!(12000, 21000));
+    }
+
+    #[test]
+    fn test_pedestrian_arrival_event() {
+
+        let mut sim = test_sim();
+
+        let ped_arrival_times = vec!(10000, 20000);
+        let veh_arrival_times = vec!(12000, 21000);
+
+        // Set the pedestrian & vehicle arrival times.
+        sim.set_ped_arrival_times(ped_arrival_times);
+        sim.set_veh_arrival_times(veh_arrival_times);
+
+        let actual = sim.time_to_next_event();
+        assert_eq!(actual, TimeDelta::new(10000));
+    }
+
+    #[test]
+    fn test_vehicle_arrival_event() {
+
+        let mut sim = test_sim();
+
+        let ped_arrival_times = vec!(5000, 7000);
+        let veh_arrival_times = vec!(4000, 15000);
+
+        // Set the pedestrian & vehicle arrival times.
+        sim.set_ped_arrival_times(ped_arrival_times);
+        sim.set_veh_arrival_times(veh_arrival_times);
+
+        let actual = sim.time_to_next_event();
+        assert_eq!(actual, TimeDelta::new(4000));
+    }
+
+    #[test]
+    fn test_vehicle_stopping_event() {
+
+        let vehicles = vec!(Car::new(0.0));
+
+        // TODO NEXT.
+        // let state = SimulatorState::dummy();
+
+    }
+
+    //
+    // Test the static helper functions.
+    //
 
     #[test]
     fn test_interarrival_time() {

--- a/src/state.rs
+++ b/src/state.rs
@@ -3,7 +3,7 @@ use crate::Time;
 use crate::time::TimeDelta;
 use crate::vehicle::{Vehicle, Car};
 
-trait State {
+pub trait State {
 
     // fn get_vehicles(&self) -> &[dyn Vehicle];
     fn timestamp(&self) -> &Time;
@@ -14,19 +14,20 @@ trait State {
     // get the list of pedestrians
     fn get_pedestrians(&self) ->  &Vec<Pedestrian>;
 
-    // get time interval until next event
-    fn time_to_next_event(&self, ped_arrival_times: &[Time], veh_arrival_times: &[Time]) -> TimeDelta;
+    // MOVED TO THE SIMULATION TRAIT:
+    // // get time interval until next event
+    // fn time_to_next_event(&self, ped_arrival_times: &[Time], veh_arrival_times: &[Time]) -> TimeDelta;
 
-    // roll state forward by time interval
-    fn roll_forward_by(&mut self, time_delta: TimeDelta);
+    // // roll state forward by time interval
+    // fn roll_forward_by(&mut self, time_delta: TimeDelta);
 
-    // update state
-    fn instantaneous_update(&mut self);
+    // // update state
+    // fn instantaneous_update(&mut self);
 
 }
 
 
-struct SimulatorState<'a> {
+pub struct SimulatorState<'a> {
 
     vehicles: Vec<Box<dyn Vehicle>>,
     pedestrians: Vec<Pedestrian<'a>>,
@@ -42,7 +43,7 @@ impl<'a> SimulatorState<'a> {
     }
 
     // Construct a state with arbitrary content
-    fn dummy(vehicles: Vec<Box<dyn Vehicle>>,
+    pub fn dummy(vehicles: Vec<Box<dyn Vehicle>>,
         pedestrians: Vec<Pedestrian<'a>>,
         timestamp: Time) -> SimulatorState<'a> {
 
@@ -65,30 +66,6 @@ impl<'a> State for SimulatorState<'a> {
     fn get_pedestrians(&self) ->  &Vec<Pedestrian> {
         &self.pedestrians
     }
-
-    // get time interval until next event
-    fn time_to_next_event(&self, ped_arrival_times: &[Time], veh_arrival_times: &[Time]) -> TimeDelta {
-	// get min of pedestrian and vehicle arrival times
-	let min_ped_times = *ped_arrival_times.iter().min().unwrap();
-	let min_veh_times = *veh_arrival_times.iter().min().unwrap();
-
-	// return the smallest of the two times as the next event
-	if min_veh_times < min_ped_times {
-	    return TimeDelta::new(min_veh_times);
-	}
-	TimeDelta::new(min_ped_times)
-    }
-
-    // roll state forward by time interval
-    fn roll_forward_by(&mut self, time_delta: TimeDelta) {
-
-    }
-
-    // update state
-    fn instantaneous_update(&mut self) {
-
-    }
-
 }
 
 #[cfg(test)]
@@ -104,43 +81,5 @@ mod tests {
 
         assert_eq!(state.get_vehicles().len(), 0); // No vehicles
         assert_eq!(state.get_pedestrians().len(), 0); // No pedestrians
-    }
-
-    #[test]
-    fn test_pedestrian_arrival_event() {
-
-        let state = SimulatorState::new();
-
-        let ped_arrival_times = vec!(10000, 20000);
-        let veh_arrival_times = vec!(12000, 21000);
-
-        let actual = state.time_to_next_event(&ped_arrival_times, &veh_arrival_times);
-
-        assert_eq!(actual, TimeDelta::new(10000));
-
-    }
-
-    #[test]
-    fn test_vehicle_arrival_event() {
-
-        let state = SimulatorState::new();
-
-        let ped_arrival_times = vec!(5000, 7000);
-        let veh_arrival_times = vec!(4000, 15000);
-
-        let actual = state.time_to_next_event(&ped_arrival_times, &veh_arrival_times);
-
-        assert_eq!(actual, TimeDelta::new(4000));
-
-    }
-
-    #[test]
-    fn test_vehicle_stopping_event() {
-
-        let vehicles = vec!(Car::new(0.0));
-
-        // TODO.
-        // let state = SimulatorState::dummy();
-
     }
 }


### PR DESCRIPTION
Moves the key methods `time_to_next_event`, `roll_forward_by` and `instantaneous_update` from State into Simulation, and adds a `state` field inside `Simulation`.

Advantages:
 - the `time_to_next_event` method now just acts on the Simulation instance (which contains all the relevant info)
 - methods `time_to_next_event` and `roll_forward_by` don't belong in the state, which is just a snapshot of the simulation.