### PR TITLE
Add direction to get_crossings()

### DIFF
--- a/src/road.rs
+++ b/src/road.rs
@@ -159,13 +159,26 @@ mod tests {
     #[test]
     fn test_road_get_crossings() {
 
-        let crossings = vec![(Crossing::Zebra { cross_time: TimeDelta::from_secs(25) }, 10.0)];
+        let crossings = vec![
+	    (Crossing::Zebra { cross_time: TimeDelta::from_secs(25) }, 10.0),
+	    (Crossing::Zebra { cross_time: TimeDelta::from_secs(10) }, 13.0),
+	];
         let road = Road::new(30.0f32, crossings);
 
 	let direction = Direction::Up;
-        assert_eq!(road.get_crossings(direction), &[(Crossing::Zebra { cross_time: TimeDelta::from_secs(25)}, 10.0)]);
+        assert_eq!(
+	    road.get_crossings(direction),
+	    &[
+		(Crossing::Zebra { cross_time: TimeDelta::from_secs(25)}, 10.0),
+		(Crossing::Zebra { cross_time: TimeDelta::from_secs(10)}, 13.0),
+	    ]);
 
 	let direction = Direction::Down;
-        assert_eq!(road.get_crossings(direction), &[(Crossing::Zebra { cross_time: TimeDelta::from_secs(25)}, 20.0)]);
+        assert_eq!(
+	    road.get_crossings(direction),
+	    &[
+		(Crossing::Zebra { cross_time: TimeDelta::from_secs(10)}, 17.0),
+		(Crossing::Zebra { cross_time: TimeDelta::from_secs(25)}, 20.0),
+	    ]);
     }
 }


### PR DESCRIPTION
Allow direction to be passed to `get_crossings()` so the order and distances is correct depending on direction of vehicle.